### PR TITLE
Pages

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -45,9 +45,11 @@ def index():
 
     page = request.args.get(get_page_parameter(), type=int, default=1)
     pagination = Pagination(page=page, items=items, total=len(items), record_name='items', per_page=20, css_framework='bulma')
+    first_index = (pagination.page-1)+((pagination.per_page-1)*(pagination.page-1))
+    last_index  = (pagination.page-1)+((pagination.per_page-1)*(pagination.page-1))+pagination.per_page
     
     return render_template(
-        "index.html", user=current_user, items=items, category_groups=category_groups, pagination=pagination
+        "index.html", user=current_user, items=items, category_groups=category_groups, pagination=pagination, first_index=first_index, last_index=last_index
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -34,8 +34,6 @@ app.login_manager = login_manager
 @app.route("/")
 @login_required
 def index():
-    page = request.args.get(get_page_parameter(), type=int, default=1)
-
     session["title"] = "D0018E - Wine Shop"
     category_groups = super_categories_and_sub()
     items = get_all_items()
@@ -45,9 +43,8 @@ def index():
     if items is None:
         items = []
 
-    pagination = Pagination(page=page, items=items, total=len(items), record_name='items', per_page=2)
-    
-    print("<app.py: index()> page: ", page,"\nitems: ", items,"\npagination: ", pagination)
+    page = request.args.get(get_page_parameter(), type=int, default=1)
+    pagination = Pagination(page=page, items=items, total=len(items), record_name='items', per_page=20, css_framework='bulma')
     
     return render_template(
         "index.html", user=current_user, items=items, category_groups=category_groups, pagination=pagination

--- a/src/app.py
+++ b/src/app.py
@@ -44,8 +44,10 @@ def index():
 
     if items is None:
         items = []
+
+    pagination = Pagination(page=page, items=items, total=len(items), record_name='items', per_page=2)
     
-    pagination = Pagination(page=page, items=items)
+    print("<app.py: index()> page: ", page,"\nitems: ", items,"\npagination: ", pagination)
     
     return render_template(
         "index.html", user=current_user, items=items, category_groups=category_groups, pagination=pagination

--- a/src/app.py
+++ b/src/app.py
@@ -9,8 +9,9 @@ from category import category
 from product import product_blueprint
 from order import order_blueprint
 from user import user_blueprint
-from flask import Flask, render_template, session
+from flask import Flask, render_template, session, request
 from flask_login import current_user, login_required
+from flask_paginate import Pagination, get_page_parameter
 from sql.inventory.getters import *
 
 # Create app
@@ -33,6 +34,8 @@ app.login_manager = login_manager
 @app.route("/")
 @login_required
 def index():
+    page = request.args.get(get_page_parameter(), type=int, default=1)
+
     session["title"] = "D0018E - Wine Shop"
     category_groups = super_categories_and_sub()
     items = get_all_items()
@@ -41,8 +44,11 @@ def index():
 
     if items is None:
         items = []
+    
+    pagination = Pagination(page=page, items=items)
+    
     return render_template(
-        "index.html", user=current_user, items=items, category_groups=category_groups
+        "index.html", user=current_user, items=items, category_groups=category_groups, pagination=pagination
     )
 
 

--- a/src/category.py
+++ b/src/category.py
@@ -1,6 +1,7 @@
 from flask.blueprints import Blueprint
 from flask import redirect, render_template, request, session
 from flask_login import login_required
+from flask_paginate import Pagination, get_page_parameter
 from require import fields
 from sql.inventory.getters import get_all_items_with_category, super_categories_and_sub
 from json import loads
@@ -33,6 +34,11 @@ def category_page():
     if categories == []:
         return redirect("/")
     items = get_all_items_with_category(categories)
+    # Pagination
+    page = request.args.get(get_page_parameter(), type=int, default=1)
+    pagination = Pagination(page=page, items=items, total=len(items), record_name='items', per_page=20, css_framework='bulma')
+    first_index = (pagination.page-1)+((pagination.per_page-1)*(pagination.page-1))
+    last_index  = (pagination.page-1)+((pagination.per_page-1)*(pagination.page-1))+pagination.per_page
     # Save the selected categories
     session["selected_categories"] = categories
     # Set the title
@@ -45,4 +51,7 @@ def category_page():
         category=categories,
         category_groups=all_categories,
         selected_categories=categories,
+        pagination=pagination,
+        first_index=first_index,
+        last_index=last_index
     )

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,8 +45,6 @@
                 </div>
                 <div class="columns"></div>
             </div>
-            {% block pages %}
-            {% endblock %}
         </div>
     </body>
 </html>

--- a/templates/category.html
+++ b/templates/category.html
@@ -11,5 +11,6 @@
 
 {% block listings %}
     <p class="title is-3">Items in category : {{ category }}</p>
-    {{ list_container(items) }}
+    {{ list_container(items[first_index : last_index]) }}
+    {{ pagination.links }}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,27 +10,6 @@
 {% endblock %}
 
 {% block listings %}
-    {{ pagination.info }}
-    {{ pagination.bulma_style }}
-    {{ list_container(items[(pagination.page-1):(pagination.page*pagination.per_page)]) }}
-    <br>
-    {% print("pagination.page: ", pagination.page, "pagination.per_page: ", pagination.per_page, "multiplication: ", pagination.page*pagination.per_page) %}
-{% endblock %}
-
-{% block pages %}
-<nav class="pagination is-centered" role="navigation" aria-label="pagination">
-    <a class="pagination-previous" title = "First page" disabled>Previous</a>
-    <a class="pagination-next">Next page</a>
-    <ul class="pagination-list">
-      <li><a class="pagination-link is-current" aria-label="Goto page 1">1</a></li>
-      <li><a class="pagination-link" aria-label="Goto page 2">2</a></li>
-      <li><a class="pagination-link" aria-label="Goto page 3">3</a></li>
-      <li><span class="pagination-ellipsis">&hellip;</span></li>
-      <li><a class="pagination-link" aria-label="Page 5" aria-current="page">5</a></li>
-      <li><span class="pagination-ellipsis">&hellip;</span></li>
-      <li><a class="pagination-link" aria-label="Goto page 10">10</a></li>
-    </ul>
-</nav>
-{{ pagination.info }}
-{{ pagination.links }}
+    {{ list_container(items[(pagination.page-1)+((pagination.per_page-1)*(pagination.page-1)) : (pagination.page-1)+((pagination.per_page-1)*(pagination.page-1))+pagination.per_page]) }}
+    {{ pagination.links }}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,6 @@
 {% endblock %}
 
 {% block listings %}
-    {{ list_container(items[(pagination.page-1)+((pagination.per_page-1)*(pagination.page-1)) : (pagination.page-1)+((pagination.per_page-1)*(pagination.page-1))+pagination.per_page]) }}
+    {{ list_container(items[first_index : last_index]) }}
     {{ pagination.links }}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,4 +27,6 @@
       <li><a class="pagination-link" aria-label="Goto page 10">10</a></li>
     </ul>
 </nav>
+{{ pagination.info }}
+{{ pagination.links }}
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,9 @@
 {% block listings %}
     {{ pagination.info }}
     {{ pagination.bulma_style }}
-    {{ list_container(items) }}
+    {{ list_container(items[(pagination.page-1):(pagination.page*pagination.per_page)]) }}
+    <br>
+    {% print("pagination.page: ", pagination.page, "pagination.per_page: ", pagination.per_page, "multiplication: ", pagination.page*pagination.per_page) %}
 {% endblock %}
 
 {% block pages %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,8 @@
 {% endblock %}
 
 {% block listings %}
+    {{ pagination.info }}
+    {{ pagination.bulma_style }}
     {{ list_container(items) }}
 {% endblock %}
 


### PR DESCRIPTION
# Pagify
When an user is on the index.html page or when categories are filtered, there will be 20 items shown on the page and the user can click on a page number at the bottom of the list of items to view more items.

### Test case
First, install pagination: `pip install -U flask-paginate`

As an admin, make sure that there are more than 20 items and then the pages will appear at the bottom of the website.
Click on the different pages to view at most 20 items per page, both in index.html and when a category is filtered.
Note: The amount of items shown can be changed by modifying the per_page parameter for the pagination object in app.py and category.py if it's too time consuming to add more than 20 items.